### PR TITLE
Fix setup.py to use namespace packaging and add missing import

### DIFF
--- a/Source/Python/generate.sh
+++ b/Source/Python/generate.sh
@@ -8,10 +8,4 @@ python3 -m grpc_tools.protoc -I./ \
                              **/*.proto
 popd
 
-# Get all folders, run mkinit
-for dir in $2/$3/*/ 
-do
-    mkinit ${dir%*/} > ${dir%*/}/__init__.py
-done
-
 sed "s@{PACKAGENAME}@$3@;s@{REPOSITORY_URL}@$4@;s@{README_FILE}@$5@;s@{VERSION}@$6@" setup.py > $2/setup.py

--- a/Source/Python/requirements.txt
+++ b/Source/Python/requirements.txt
@@ -1,3 +1,2 @@
 twine==2.0.0
 grpcio-tools==1.24.1
-mkinit==0.2.0

--- a/Source/Python/setup.py
+++ b/Source/Python/setup.py
@@ -1,11 +1,11 @@
-from setuptools import setup
+from setuptools import setup, find_namespace_packages
 
 with open('{README_FILE}') as f:
     long_description = f.read()
 
 setup(
   name = '{PACKAGENAME}',
-  packages = ['{PACKAGENAME}'],
+  packages = find_namespace_packages(),
   version = '{VERSION}',
   license='MIT',
   long_description=long_description,
@@ -15,7 +15,8 @@ setup(
   url = '{REPOSITORY_URL}',
   keywords = ['Dolittle', 'gRPC', 'Contracts'],
   install_requires=[
-    'protobuf3'
+    'protobuf3',
+    'protobuf'
   ],
   python_requires='>=3.3',
   classifiers=[


### PR DESCRIPTION
The code generated by protoc is using namespace packages (aka no `__init__.py`) by default so I don't think we need to add more complexity/dependencies with mkinit unless we have a reason to move away from namespace packages to old style modules.

More thought needs to be put into the package folder structure in the future depending on how we want the imports to look in the future and then we might need to create some `__init__.py` files for all the folders.